### PR TITLE
Fixed scene texture being deleted on first iteration of main loop

### DIFF
--- a/src/ui/display.cpp
+++ b/src/ui/display.cpp
@@ -645,8 +645,8 @@ void cr::display::start(
         ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
         glfwSwapBuffers(_glfw_window);
 
-        glDeleteTextures(1, &_scene_texture_handle);
     }
+    glDeleteTextures(1, &_scene_texture_handle);
     stop();
 }
 


### PR DESCRIPTION
_scene_texture_handle was deleted inside of the main loop. Moved it to after the main loop so it is deleted when the window closes.