### PR TITLE
Shader development QOL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,4 +68,4 @@ target_include_directories(CRender PRIVATE external)
 
 target_link_libraries(CRender glfw fmt glm embree OpenImageDenoise)
 
-target_compile_definitions(CRender PUBLIC -DGLFW_INCLUDE_NONE -D__STDC_CONSTANT_MACROS)
+target_compile_definitions(CRender PUBLIC -DGLFW_INCLUDE_NONE -D__STDC_CONSTANT_MACROS -DCRENDER_ASSET_PATH="${CMAKE_SOURCE_DIR}/assets/app/")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ project(CRender)
 
 set(EMBREE_ISA_AVX256 ON)
 
+option(CRENDER_USE_RELATIVE_ASSET_PATH "Enabled during development, for production builds disable" OFF)
+
 if (CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC" AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     message(STATUS "Using clang-cl options (MSVC interface)")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR- /arch:AVX /MT /W4 /EHa /EHs")
@@ -68,4 +70,12 @@ target_include_directories(CRender PRIVATE external)
 
 target_link_libraries(CRender glfw fmt glm embree OpenImageDenoise)
 
-target_compile_definitions(CRender PUBLIC -DGLFW_INCLUDE_NONE -D__STDC_CONSTANT_MACROS -DCRENDER_ASSET_PATH="${CMAKE_SOURCE_DIR}/assets/app/")
+if (CRENDER_USE_RELATIVE_ASSET_PATH)
+    message("Using relative asset path")
+    set(CRENDER_ASSET_PATH_VAR "./assets/app/")
+else()
+    message("Using none-relative asset path")
+    set(CRENDER_ASSET_PATH_VAR "${CMAKE_SOURCE_DIR}/assets/app/")
+endif()
+
+target_compile_definitions(CRender PUBLIC -DGLFW_INCLUDE_NONE -D__STDC_CONSTANT_MACROS -DCRENDER_ASSET_PATH="${CRENDER_ASSET_PATH_VAR}")

--- a/src/render/draft/draft_renderer.cpp
+++ b/src/render/draft/draft_renderer.cpp
@@ -21,7 +21,7 @@ cr::draft_renderer::draft_renderer(
     // Load shaders in
     // Load the shader into the string
     {
-        auto shader_file_in_stream = std::ifstream("./assets/app/shaders/draft_mode.vert");
+        auto shader_file_in_stream = std::ifstream(std::string(CRENDER_ASSET_PATH) + "shaders/draft_mode.vert");
         auto shader_string_stream  = std::stringstream();
         shader_string_stream << shader_file_in_stream.rdbuf();
         const auto shader_source = shader_string_stream.str();
@@ -45,7 +45,7 @@ cr::draft_renderer::draft_renderer(
     }
 
     {
-        auto shader_file_in_stream = std::ifstream("./assets/app/shaders/draft_mode.frag");
+        auto shader_file_in_stream = std::ifstream(std::string(CRENDER_ASSET_PATH) + "shaders/draft_mode.frag");
         auto shader_string_stream  = std::stringstream();
         shader_string_stream << shader_file_in_stream.rdbuf();
         const auto shader_source = shader_string_stream.str();
@@ -96,7 +96,7 @@ cr::draft_renderer::draft_renderer(
 
     {
         auto shader_file_in_stream =
-          std::ifstream("./assets/app/shaders/draft_mode_background.comp");
+          std::ifstream(std::string(CRENDER_ASSET_PATH) + "shaders/draft_mode_background.comp");
         auto shader_string_stream = std::stringstream();
         shader_string_stream << shader_file_in_stream.rdbuf();
         const auto shader_source = shader_string_stream.str();

--- a/src/ui/display.cpp
+++ b/src/ui/display.cpp
@@ -46,7 +46,7 @@ cr::display::display()
 
     // Load the compute shader into the string
     {
-        auto shader_file_in_stream = std::ifstream("./assets/app/shaders/scene_zoom.comp");
+        auto shader_file_in_stream = std::ifstream(std::string(CRENDER_ASSET_PATH) + "shaders/scene_zoom.comp");
         auto shader_string_stream  = std::stringstream();
         shader_string_stream << shader_file_in_stream.rdbuf();
         const auto shader_source = shader_string_stream.str();
@@ -145,7 +145,7 @@ void cr::display::start(
     auto &io = ImGui::GetIO();
     io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
 
-    const auto font = io.Fonts->AddFontFromFileTTF("./assets/app/fonts/Oxygen-Regular.ttf", 18.f);
+    const auto font = io.Fonts->AddFontFromFileTTF((std::string(CRENDER_ASSET_PATH) + "fonts/Oxygen-Regular.ttf").c_str(), 18.f);
 
     cr::ImGuiThemes::CorporateGrey();
 

--- a/src/util/sampling.h
+++ b/src/util/sampling.h
@@ -104,10 +104,8 @@ namespace cr::sampling
          * Specular G (Geometric Shadowing)
          *
          *                                                          0.5
-         * V(v,l,a) =
-         * -----------------------------------------------------------------------------------------
-         *            n * l sqrt((n * v) ^ 2 (1 - a ^ 2) + a ^ 2) + n * v sqrt((n * l) ^ 2 (1 - a ^
-         * 2) + a ^ 2)
+         * V(v,l,a) = -----------------------------------------------------------------------------------------
+         *            n * l sqrt((n * v) ^ 2 (1 - a ^ 2) + a ^ 2) + n * v sqrt((n * l) ^ 2 (1 - a ^ 2) + a ^ 2)
          *
          */
         [[nodiscard]] inline float specular_g(float NoV, float NoL, float roughness)


### PR DESCRIPTION
Previously, developing shaders was a relatively easy task. This pull request adds a define (and uses it) to make sure that if you have a different running directory for the application. That CRender (in development mode) will use the source directory assets, meaning you can work on shaders and have them in there nicely.

This is a pdevelopment only pull request, there are no fancy effects added with this :pensive: