### PR TITLE
Replaced hardcoded numbers w/ consts

### DIFF
--- a/src/imgui/imgui_demo.cpp
+++ b/src/imgui/imgui_demo.cpp
@@ -89,6 +89,8 @@ Index of this file:
 #include <stddef.h>         // intptr_t
 #else
 #include <stdint.h>         // intptr_t
+
+#include <util/numbers.h>
 #endif
 
 // Visual Studio warnings
@@ -3249,7 +3251,7 @@ static void ShowDemoWindowPopups()
         if (ImGui::BeginPopupContextItem("item context menu"))
         {
             if (ImGui::Selectable("Set to zero")) value = 0.0f;
-            if (ImGui::Selectable("Set to PI")) value = 3.1415f;
+            if (ImGui::Selectable("Set to PI")) value = cr::numbers<float>::pi;
             ImGui::SetNextItemWidth(-FLT_MIN);
             ImGui::DragFloat("##Value", &value, 0.1f, 0.0f, 0.0f);
             ImGui::EndPopup();

--- a/src/imgui/imstb_truetype.h
+++ b/src/imgui/imstb_truetype.h
@@ -457,6 +457,7 @@ int main(int arg, char **argv)
 
    #ifndef STBTT_cos
    #include <math.h>
+   #include <util/numbers.h>
    #define STBTT_cos(x)       cos(x)
    #define STBTT_acos(x)      acos(x)
    #endif
@@ -4391,7 +4392,7 @@ static int stbtt__solve_cubic(float a, float b, float c, float* r)
 	   float u = (float) STBTT_sqrt(-p/3);
 	   float v = (float) STBTT_acos(-STBTT_sqrt(-27/p3) * q / 2) / 3; // p3 must be negative, since d is negative
 	   float m = (float) STBTT_cos(v);
-      float n = (float) STBTT_cos(v-3.141592/2)*1.732050808f;
+      float n = (float) STBTT_cos(v-cr::numbers<double>::half_pi)*cr::numbers<float>::sqrt_3;
 	   r[0] = s + u * 2 * m;
 	   r[1] = s - u * (m + n);
 	   r[2] = s - u * (m - n);

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -1,4 +1,5 @@
 #include "renderer.h"
+#include <util/numbers.h>
 
 namespace
 {
@@ -276,8 +277,8 @@ void cr::renderer::_sample_pixel(uint64_t x, uint64_t y, size_t &fired_rays)
         if (intersection.distance == std::numeric_limits<float>::infinity())
         {
             const auto miss_uv = glm::vec2(
-              0.5f + atan2f(ray.direction.z, ray.direction.x) / (2 * 3.1415f),
-              0.5f - asinf(ray.direction.y) / 3.1415f);
+              0.5f + atan2f(ray.direction.z, ray.direction.x)*(cr::numbers<float>::inv_tau),
+              0.5f - asinf(ray.direction.y) * cr::numbers<float>::inv_pi);
 
             const auto miss_sample = _scene->get()->sample_skybox(miss_uv.x, miss_uv.y);
 

--- a/src/util/numbers.h
+++ b/src/util/numbers.h
@@ -13,10 +13,14 @@ namespace cr
     public:
         inline constexpr static float e   = 2.71828182845f;
         inline constexpr static float pi  = 3.14159265359f;
+        inline constexpr static float half_pi = 3.14159265359f / 2.0f;
         inline constexpr static float tau = 6.28318530717f;
+
+        inline constexpr static float sqrt_3 = 1.732050808f;
 
         inline constexpr static float inv_e   = 1.0f / 2.71828182845f;
         inline constexpr static float inv_pi  = 1.0f / 3.14159265359f;
+        inline constexpr static float two_over_pi = 2.0f / 3.14159265359f;
         inline constexpr static float inv_tau = 1.0f / 6.28318530717f;
     };
 
@@ -26,10 +30,14 @@ namespace cr
     public:
         inline constexpr static double e   = 2.71828182845;
         inline constexpr static double pi  = 3.14159265359;
+        inline constexpr static double half_pi = 3.14159265359 / 2.0;
         inline constexpr static double tau = 6.28318530717;
+
+        inline constexpr static double sqrt_3 = 1.732050808;
 
         inline constexpr static double inv_e   = 1.0 / 2.71828182845;
         inline constexpr static double inv_pi  = 1.0 / 3.14159265359;
+        inline constexpr static double two_over_pi = 2.0 / 3.14159265359;
         inline constexpr static double inv_tau = 1.0 / 6.28318530717;
     };
 

--- a/src/util/sampling.h
+++ b/src/util/sampling.h
@@ -92,12 +92,10 @@ namespace cr::sampling
          */
         [[nodiscard]] inline float specular_d(float NoH, float roughness)
         {
-            constexpr auto pi = 3.141592f;
-
             const auto a2 = roughness * roughness;
             const auto d  = ((NoH * a2 - NoH) * NoH + 1.0f);
 
-            return a2 / (d * d * pi);
+            return a2 / (d * d * cr::numbers<float>::pi);
         }
 
         /**
@@ -160,7 +158,7 @@ namespace cr::sampling
         const auto cos_theta = 2.0f * uv.x - 1.0f;
         const auto sin_theta = glm::sqrt(1.0f - cos_theta * cos_theta);
 
-        const auto phi     = 2.0f * 3.1415f * uv.y;
+        const auto phi     = cr::numbers<float>::tau * uv.y;
         const auto sin_phi = glm::sin(phi);
         const auto cos_phi = glm::cos(phi);
 
@@ -176,7 +174,7 @@ namespace cr::sampling
     [[nodiscard]] inline glm::vec3 cos_hemp(const float x, const float y)
     {
         const auto r     = sqrtf(x);
-        const auto theta = 6.283f * y;
+        const auto theta = cr::numbers<float>::tau * y;
 
         const auto u = r * cosf(theta);
         const auto v = r * sinf(theta);


### PR DESCRIPTION
Replaced all hardcoded known constants (e.g, pi, 2*pi, and pi/2) with constexprs defined in util/numbers.h.